### PR TITLE
Add option for table outputs to be taken from the side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2023-12-11 - 1.2.3
+- Added a configurable option to allow taking outputs from the side of a delivery table. Off by default.
+
 2023-11-10 - 1.2.2
 - Added ability to keep item nbt-tags when opening Sealed Agreement. Can be configured.
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 apply plugin: 'org.spongepowered.mixin'
 
-version = '1.2.2'
+version = '1.2.3'
 group = 'io.github.mortuusars.wares' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "wares-${mc_version}"
 

--- a/src/main/java/io/github/mortuusars/wares/block/entity/DeliveryTableBlockEntity.java
+++ b/src/main/java/io/github/mortuusars/wares/block/entity/DeliveryTableBlockEntity.java
@@ -60,6 +60,7 @@ public class DeliveryTableBlockEntity extends BaseContainerBlockEntity implement
     public static final int[] INPUT_PLUS_PACKAGES_SLOTS = new int[] {1,2,3,4,5,6,7};
     public static final int[] INPUT_SLOTS = new int[] {2,3,4,5,6,7};
     public static final int[] OUTPUT_SLOTS = new int[] {8,9,10,11,12,13};
+    public static final int[] INPUT_PLUS_OUTPUT_SLOTS = new int[] {2,3,4,5,6,7,8,9,10,11,12,13};
 
     public static final int PACKAGER_WORK_RADIUS = 3;
     public static final int PACKAGER_LAST_WORK_THRESHOLD = 20 * 40; // 40 seconds = 800 ticks
@@ -503,7 +504,7 @@ public class DeliveryTableBlockEntity extends BaseContainerBlockEntity implement
         return switch (side) {
             case DOWN -> OUTPUT_SLOTS;
             case UP -> Config.DELIVERIES_REQUIRE_BOXES.get() ? AGREEMENT_PLUS_PACKAGES_SLOTS : AGREEMENT_SLOTS;
-            case NORTH, SOUTH, WEST, EAST -> INPUT_SLOTS;
+            case NORTH, SOUTH, WEST, EAST -> Config.TABLE_OUTPUTS_FROM_SIDES.get() ? INPUT_PLUS_OUTPUT_SLOTS : INPUT_SLOTS;
         };
     }
 

--- a/src/main/java/io/github/mortuusars/wares/config/Config.java
+++ b/src/main/java/io/github/mortuusars/wares/config/Config.java
@@ -23,6 +23,7 @@ public class Config {
     public static final ForgeConfigSpec.ConfigValue<List<? extends Integer>> PACKAGER_XP_PER_LEVEL;
     public static final ForgeConfigSpec.IntValue DEFAULT_DELIVERY_TIME;
     public static final ForgeConfigSpec.BooleanValue DELIVERIES_REQUIRE_BOXES;
+    public static final ForgeConfigSpec.BooleanValue TABLE_OUTPUTS_FROM_SIDES;
 
     public static final ForgeConfigSpec.BooleanValue GENERATE_WAREHOUSES;
     public static final ForgeConfigSpec.IntValue WAREHOUSE_WEIGHT;
@@ -87,6 +88,11 @@ public class Config {
                 .comment("Each delivery requires (and consumes) a packaging. ('wares:delivery_boxes' tag)",
                         "A slot for boxes will be added to delivery table. Default: true")
                 .define("DeliveriesRequireBoxes", true);
+
+        TABLE_OUTPUTS_FROM_SIDES = builder
+                .comment("Delivery outputs can be taken by consumers from the side of the delivery table, in addition to the bottom.",
+                        "Default: false")
+                .define("TableOutputsFromSides", false);
 
         builder.pop();
 


### PR DESCRIPTION
A configurable option to allow item consumers to take delivery outputs from the sides of a delivery table.

A feature we need for our modpack (since we made the table immovable, and it is placed on bedrock).
I made it off by default, to not change behavior unexpectedly for users.